### PR TITLE
Rename CLI commands in package.json bin section to use mcp-remote-audience

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "main": "dist/index.js",
   "bin": {
-    "mcp-remote": "dist/proxy.js",
-    "mcp-remote-client": "dist/client.js"
+    "mcp-remote-audience": "dist/proxy.js",
+    "mcp-remote-audience-client": "dist/client.js"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary
This PR updates the CLI command names in the `package.json` bin section for better consistency with the new package naming.

## Changes
- Renamed `mcp-remote` → `mcp-remote-audience`
- Renamed `mcp-remote-client` → `mcp-remote-audience-client`

## Motivation
As part of the package rename, the CLI commands should also reflect the updated naming convention. This ensures consistency across package distribution and command-line usage.

## Impact
- **Breaking change**: Users must now invoke the CLI using `mcp-remote-audience` and `mcp-remote-audience-client`.
- **No functional changes**: Only command names were updated; behavior remains the same.